### PR TITLE
Switch to HTTP::UserAgent and fix Perl 6 rename fallout

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2020-08-29  Norbert Buchmueller <norbi@nix.hu>
+
+	* lib/Pod/To/BigPage.pm6: Switched from LWP::Simple to HTTP::UserAgent
+	* t/P.t: Fixed fallout from Perl 6 to Raku rename
+
 2019-01-13  Juan J. merelo  <jmerelo@penny>
 
 	* META6.json: Bumps up after fixing the problem with links-that-were-arrays: https://github.com/perl6/perl6-pod-to-bigpage/issues/34

--- a/META6.json
+++ b/META6.json
@@ -1,7 +1,7 @@
 {
     "perl" : "6.*",
     "name" : "Pod::To::BigPage",
-    "version" : "0.5.1",
+    "version" : "0.5.2",
     "author" : "Perl 6",
     "description" : "Render many pod6-files into one (big) html-file.",
     "license" : "Artistic-2.0",

--- a/META6.json
+++ b/META6.json
@@ -11,7 +11,7 @@
     "support" : {
         "source" : "https://github.com/perl6/perl6-pod-to-bigpage"
     },
-    "depends" : [ "LWP::Simple" ],
+    "depends" : [ "HTTP::UserAgent", "URI" ],
     "test-depends" : [
         "Test",
         "Test::When",

--- a/t/P.t
+++ b/t/P.t
@@ -11,11 +11,11 @@ plan 1;
 =begin pod
 =head1 This is the head
 P<./t/hello-camelia.txt>
-P<http://http.perl6.org/robots.txt>
+P<https://www.raku.org/robots.txt>
 =end pod
 
 my $ok-result = q:to/EOH/;
- <h1 id="_routine_test.pod6-This_is_the_head_./t/hello-camelia.txt_http://http.perl6.org/robots.txt">This is the head <pre>Hello Camelia!
+ <h1 id="_routine_test.pod6-This_is_the_head_./t/hello-camelia.txt_https://www.raku.org/robots.txt">This is the head <pre>Hello Camelia!
 </pre> <pre>User-Agent: *
 Disallow: /page-stats
 </pre></h1>


### PR DESCRIPTION
This PR switches from LWP::Simple to HTTP::UserAgent and fixes the `P<>` test (fallout from Perl 6 to Raku rename).

This should fix #35 and #30.